### PR TITLE
Initial proposal for logging standard

### DIFF
--- a/docs/proposals/conformance/standard.md
+++ b/docs/proposals/conformance/standard.md
@@ -4,7 +4,7 @@
 
 ### Overview
 
-This specification describes requirements for a containerized environment to run a conformance test, which performs the followin operations:
+This specification describes requirements for a containerized environment to run a conformance test, which performs the following operations:
 
 1. Validate configuration inputs using published schemas
 1. Download required files

--- a/docs/proposals/logging.md
+++ b/docs/proposals/logging.md
@@ -1,0 +1,76 @@
+# Logging
+
+## 📐 Standard
+
+### Overview
+
+This specification describes logging requirements for all FFRD containers, ensuring that logs are consistent,
+useful, and compatible with modern workflows.
+
+## 📝 Specification
+
+#### 1. Re-emit `stdout`
+
+Containers must re-emit messages logged to `stdout` by the main process.
+
+In some cases, the container may filter or aggregate superflous logs to `stdout`.
+For example, the HEC-RAS 6.x Unsteady process is extremely "chatty", indicating its progress by
+echoing each individual timestep to `stdout`. Logs from a HEC-RAS 6.x container will be more legible if messages
+from the Unsteady process are filtered to increments of, e.g., 1%, 5%, or 10% progress.
+
+#### 2. Tail and echo relevant log files
+
+Containers must tail and re-emit messages logged to log files by the main process.
+
+For example, in HEC-HMS v4.x, logs are saved in `*.log` and `*.out` files within the directory of a project.
+A HEC-HMS v4.x container should echo messages saved to these files while a HEC-HMS model runs.
+
+#### 3. Log message formatting
+
+Containers must write log messages in a format which includes:
+
+1. ISO timestamp
+1. Level (e.g., `ERROR`, `WARNING`, `INFO`)
+1. Path to the log file where the log message was written (not applicable to messages written to `stdout`)
+1. The original log message
+
+Example:
+
+```
+2025-08-04 20:12:32,958 - INFO - /app/HEC-HMS-4.12/samples/tenk/tenk.log - NOTE 10181:  Opened control specifications "Jan 96" at time 04Aug2025, 20:12:32.
+2025-08-04 20:12:32,958 - INFO - /app/HEC-HMS-4.12/samples/tenk/tenk.log - NOTE 10616:  Data type "PER-AVER" is usually used for time intervals of 24 hours or longer.  Gage "TENK".
+2025-08-04 20:12:32,959 - WARNING - /app/HEC-HMS-4.12/samples/tenk/tenk.log - WARNING 40503:  Missing precipitation set to zero for 129 of 129 grid cells at 18Jan1996, 17:00 for gridded subbasin "86".
+2025-08-04 20:12:32,959 - WARNING - /app/HEC-HMS-4.12/samples/tenk/tenk.log - WARNING 40503:  Missing precipitation set to zero for 84 of 84 grid cells at 18Jan1996, 17:00 for gridded subbasin "85".
+2025-08-04 20:12:32,959 - WARNING - /app/HEC-HMS-4.12/samples/tenk/tenk.log - WARNING 40503:  Missing precipitation set to zero for 78 of 78 grid cells at 18Jan1996, 17:00 for gridded subbasin "113".
+2025-08-04 20:12:32,958 - INFO - /app/HEC-HMS-4.12/samples/tenk/Jan_96_storm.log - grid cells at 20Jan1996, 02:00 for gridded subbasin "127".
+```
+
+#### 4. JSON log message formatting
+
+Containers must provide an option to emit log messages as JSON. JSON-formatted logs are valuable in modern logging
+pipelines because they can be easily parsed, indexed, and queried by log aggregation systems. This enables filtering
+by timestamp, severity level, model component, and file source, allowing teams to detect issues faster and build
+dashboards or alerting mechanisms.
+
+JSON log messages must abide by the following schema:
+
+```json
+{% include "../../reference/logs/logs-schema.json" %}
+```
+
+Example:
+
+```json
+{"timestamp": "2025-08-04T20:20:40.141323", "level": "WARNING", "source": "/app/HEC-HMS-4.12/samples/tenk/Jan_96_storm.log", "message": "WARNING 40503:  Missing precipitation set to zero for 86 of 86 grid cells at 20Jan1996, 22:00 for gridded subbasin \"127\"."}
+{"timestamp": "2025-08-04T20:20:40.141370", "level": "INFO", "source": "/app/HEC-HMS-4.12/samples/tenk/Jan_96_storm.log", "message": "NOTE 15302:  Finished computing simulation run \"Jan 96 storm\" at time 04Aug2025, 20:20:39."}
+{"timestamp": "2025-08-04T20:20:40.141409", "level": "INFO", "source": "/app/HEC-HMS-4.12/samples/tenk/Jan_96_storm.log", "message": "NOTE 15312:  The total runtime for this simulation is 00:01."}
+```
+
+#### 5. Return codes
+
+Containers must exit with clear return codes indicating the success or failure of the primary process.
+This enables automation and orchestration systems to make informed decisions -- such as whether to retry a failed
+job, trigger a downstream task, or alert a human operator.
+
+- `0`: Success
+- `1`: Failure

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ nav:
 
   - Proposals:
     - proposals/conformance/conformance.md
+    - proposals/logging.md
 
   - Appendix:
     - references.md

--- a/reference/hms/v411/Dockerfile
+++ b/reference/hms/v411/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:7.3.1-jdk17 as javabuilder
+FROM gradle:7.3.1-jdk17 AS javabuilder
 
 USER root
 RUN apt update && apt -y install wget unzip libxrender1 libxtst6 libxi6 libfreetype6 libgfortran5 libfontconfig1

--- a/reference/hms/v412/hms_cli.py
+++ b/reference/hms/v412/hms_cli.py
@@ -5,6 +5,48 @@ import tempfile
 import os
 import sys
 import json
+from time import sleep
+import threading
+from glob import glob
+from datetime import datetime
+import logging
+
+
+class JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        log_record = {
+            'timestamp': datetime.now().isoformat(),
+            'level': record.levelname,
+            'source': getattr(record, 'source', None),
+            'message': record.getMessage(),
+        }
+        if record.exc_info:
+            log_record['exception'] = self.formatException(record.exc_info)
+        return json.dumps(log_record)
+
+
+class TextFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        if not hasattr(record, 'source'):
+            record.source = "-"
+        return super().format(record)
+
+
+def configure_logging(log_format: str):
+    handler = logging.StreamHandler(sys.stdout)
+    if log_format == 'json':
+        formatter = JsonFormatter()
+    else:
+        formatter = TextFormatter('%(asctime)s - %(levelname)s - %(source)s - %(message)s')
+    handler.setFormatter(formatter)
+    logging.basicConfig(
+        level=logging.INFO,
+        handlers=[handler],
+        force=True,
+    )
+
+logger = logging.getLogger(__name__)
+
 
 JYTHON_TEMPLATE = '''from hms.model.JythonHms import *
 OpenProject("{project_name}", "{project_dir}")
@@ -12,18 +54,45 @@ ComputeRun("{sim_name}")
 SaveAllProjectComponents()
 '''
 
+
+def stream_tail(path):
+    proc = subprocess.Popen(
+        ['tail', '-n', '0', '-F', str(path)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1, # Line-buffered output
+    )
+    with proc.stdout:
+        for line in proc.stdout:
+            l = line.strip()
+            if not l:
+                continue
+            elif "WARNING" in l:
+                logger.warning(l, extra={'source': path})
+            elif "NOTE" in l:
+                logger.info(l, extra={'source': path})
+            elif "ERROR" in l:
+                logger.error(l, extra={'source': path})
+            else:
+                logger.info(l, extra={'source': path})
+
+
 def main():
     parser = argparse.ArgumentParser(description="HEC-HMS CLI Runner")
-    parser.add_argument('--project_file', type=str, help='Path to the .hms project file')
-    parser.add_argument('--sim_name', type=str, help='Simulation name to run')
+    parser.add_argument('--project-file', type=str, help='Path to the .hms project file')
+    parser.add_argument('--sim-name', type=str, help='Simulation name to run')
     parser.add_argument('--example', choices=['tenk'], help='Run a built-in example project')
-    parser.add_argument('--json_file', type=str, help='Path to a JSON file with hms_schema')
+    parser.add_argument('--json-file', type=str, help='Path to a JSON file with hms_schema')
+    parser.add_argument('--log-format', type=str, default='text', choices=['text', 'json'], help='Log format (default: text)')
     args = parser.parse_args()
+
+    configure_logging(args.log_format)
 
     input_methods = sum([bool(args.example), bool(args.json_file), bool(args.project_file and args.sim_name)])
     if input_methods != 1:
-        print("Error: Specify exactly one input method: --example, --json_file, or both --project_file and --sim_name.")
-        sys.exit(1)
+        logger.error("Error: Specify exactly one input method: --example, --json-file, or both --project-file and --sim-name.")
+        return 1
 
     if args.example == 'tenk':
         hms_file = "/app/HEC-HMS-4.12/samples/tenk/tenk.hms"
@@ -36,18 +105,18 @@ def main():
             hms_file = hms_schema.get('project_file')
             sim_name = hms_schema.get('sim_name')
         except Exception as e:
-            print(f"Error reading or parsing JSON: {e}")
-            sys.exit(1)
+            logger.error(f"Error reading or parsing JSON: {e}")
+            return 1
         if not hms_file or not sim_name:
-            print("Error: JSON must contain hms_schema with project_file and sim_name.")
-            sys.exit(1)
+            logger.error("JSON must contain hms_schema with project_file and sim_name.")
+            return 1
     else:
         hms_file = args.project_file
         sim_name = args.sim_name
 
     if not hms_file or not hms_file.lower().endswith('.hms'):
-        print("Error: project_file must be a .hms file")
-        sys.exit(1)
+        logger.error("Error: project_file must be a .hms file")
+        return 1
     project_dir = os.path.dirname(os.path.abspath(hms_file))
     project_name = os.path.splitext(os.path.basename(hms_file))[0]
 
@@ -83,12 +152,23 @@ def main():
     env['GDAL_DATA'] = f"{hms_home}/bin/gdal/gdal-data"
     env['PROJ_LIB'] = f"{hms_home}/bin/gdal/proj"
 
+    log_files = glob(str(project_dir) + '/*.log') + glob(str(project_dir) + '/*.out')
+    for log_file in log_files:
+        threading.Thread(target=stream_tail, args=(log_file,), daemon=True).start()
+
     # Run the Java process
     try:
-        subprocess.run(java_cmd, env=env, check=True)
-        print(f"Simulation '{sim_name}' completed successfully for project '{project_name}' in directory '{project_dir}'.")
+        proc = subprocess.Popen(java_cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1)
+        with proc.stdout:
+            for line in proc.stdout:
+                logger.info(line.strip())
+        proc.wait()
+        logger.info(f"Simulation '{sim_name}' completed successfully for project '{project_name}' in directory '{project_dir}'.")
+        return proc.returncode
     finally:
+        sleep(1)  # Allow some time for log threads to finish
         os.remove(script_path)
 
 if __name__ == "__main__":
-    main()
+    returncode = main()
+    sys.exit(returncode)

--- a/reference/logs/logs-schema.json
+++ b/reference/logs/logs-schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/logs-schema.json",
+  "title": "FFRD Log Format",
+  "description": "Schema for the FFRD log format",
+  "version": "0.1.0",
+  "type": "object",
+  "properties": {
+    "timestamp": {
+      "description": "The timestamp of the log entry",
+      "type": "string",
+      "format": "date-time"
+    },
+    "level": {
+      "description": "The log level",
+      "type": "string",
+      "enum": ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+    },
+    "source": {
+      "description": "The source of the log entry; e.g., the file path to the log file. This can be null if the log entry is not associated with a specific file.",
+      "type": ["string", "null"]
+    },
+    "message": {
+      "description": "The log message",
+      "type": "string"
+    }
+  },
+  "required": [ "timestamp", "level", "source", "message" ]
+}


### PR DESCRIPTION
# Description
* Implements logging with the existing HEC-HMS v4.12 example container by echoing STDOUT messages and tailing `*.log` and `*.out` files.
* Brief write-up about logging standards. 
  * **Should this go in Drafts? Or Proposals?**
* JSON schema for JSON-based log messages.

Will probably be re-working this a bit as the v4.11 Java-based example might be a better foundation for a HEC-HMS reference implementation, but wanted to get eyes on it.