### PR TITLE
fix actions issue with tagging 'latest' hms-runner image

### DIFF
--- a/.github/workflows/deploy-hms.yml
+++ b/.github/workflows/deploy-hms.yml
@@ -44,5 +44,6 @@ jobs:
       - name: Tag latest
         if: ${{ matrix.hms_version == env.LATEST_HMS_VERSION }}
         run: |
+          docker pull $IMAGE:${{ matrix.hms_version }}
           docker tag $IMAGE:${{ matrix.hms_version }} $IMAGE:latest
           docker push $IMAGE:latest


### PR DESCRIPTION
Fixes this build issue:
<img width="660" height="542" alt="image" src="https://github.com/user-attachments/assets/b746906f-23d9-4fdc-bce3-015dc48262f3" />

https://github.com/fema-ffrd/specs/actions/runs/17159026696/job/48683394839