### PR TITLE
HMS container: export excess precip

### DIFF
--- a/.github/workflows/ci-hms.yml
+++ b/.github/workflows/ci-hms.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        hms_version: [ "4.10", "4.11", "4.12" ]
+        hms_version: [ "4.10", "4.11", "4.12", "4.13-beta.6" ]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/deploy-hms.yml
+++ b/.github/workflows/deploy-hms.yml
@@ -9,14 +9,14 @@ on:
 
 env:
   IMAGE: ghcr.io/${{ github.repository_owner }}/hms-runner
-  LATEST_HMS_VERSION: 4.12   # for tagging 'latest'
+  LATEST_HMS_VERSION: "4.13-beta.6"   # for tagging 'latest'
 
 jobs:
   build-push-hms-runner:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        hms_version: [ "4.10", "4.11", "4.12" ]
+        hms_version: [ "4.10", "4.11", "4.12", "4.13-beta.6" ]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/reference/hms/hms-golang/README.md
+++ b/reference/hms/hms-golang/README.md
@@ -7,13 +7,13 @@ A HEC-HMS runner image built with Go, with logging.
 To build the image:
 
 ```
-docker build -t go-hms-runner .
+docker build -t hms-runner .
 ```
 
 To build with a specific version of HMS, use the `HMS_VERSION` build argument.
 
 ```
-docker build -t go-hms-runner:4.11 --build-arg HMS_VERSION=4.11 .
+docker build -t hms-runner:4.11 --build-arg HMS_VERSION=4.11 .
 ```
 
 ## Run
@@ -21,46 +21,68 @@ docker build -t go-hms-runner:4.11 --build-arg HMS_VERSION=4.11 .
 See the CLI help:
 
 ```
-docker run go-hms-runner --help
+docker run hms-runner --help
 ```
+
+### Running the Tenk Example
 
 To run the included Tenk example model:
 
 ```
-docker run go-hms-runner --example
+docker run hms-runner --example
 ```
 
 or, alternatively:
 
 ```
-docker run go-hms-runner --project-file /opt/HEC-HMS-4.12/samples/tenk/tenk.hms --sim-name "Jan 96 storm"
+docker run hms-runner --project-file /opt/HEC-HMS-4.12/samples/tenk/tenk.hms --sim-name "Jan 96 storm"
 ```
 
 Run the Tenk example by mounting a volume:
 
 ```
-docker run -v /mnt/c/temp/hms-samples/:/tmp/samples go-hms-runner --project-file /tmp/samples/tenk/tenk.hms --sim-name "Jan 96 storm"
+docker run -v /mnt/c/temp/hms-samples/:/tmp/samples hms-runner --project-file /tmp/samples/tenk/tenk.hms --sim-name "Jan 96 storm"
 ```
 
 To run the Tenk example with a JSON file, first create a JSON file based on the HMS schema:
 
 ```json
 {
-    "hms_schema": {
-        "project_file": "/opt/HEC-HMS-4.12/samples/tenk/tenk.hms",
-        "sim_name": "Jan 96 storm"
-    }
+    "project_file": "/opt/HEC-HMS-4.12/samples/tenk/tenk.hms",
+    "sim_name": "Jan 96 storm"
 }
 ```
 
 Then, to use the JSON file to configure the input parameters:
 
 ```
-docker run -v .:/tmp go-hms-runner --json-file /tmp/tenk.json
+docker run -v .:/tmp hms-runner --json-file /tmp/tenk.json
 ```
 
 Use the `--log-format` flag to output logs as JSON:
 
 ```
-docker run go-hms-runner --project-file /opt/HEC-HMS-4.12/samples/tenk/tenk.hms --sim-name "Jan 96 storm" --log-format json
+docker run hms-runner --project-file /opt/HEC-HMS-4.12/samples/tenk/tenk.hms --sim-name "Jan 96 storm" --log-format json
+```
+
+### Run and Export Spatial Excess Precipitation
+
+To run a model with spatially distributed precipitation and then export excess preciptation grids in HEC-RAS HDF format (`.p##.tmp.hdf`) or `.dss` format:
+
+```
+$ docker run -it -v /tmp/trinity:/workspace/trinity hms-runner --project-file /workspace/trinity/trinity.hms --sim-name apr-may-1990 --excess-precip /workspace/trinity/excess-precip.p01.tmp.hdf
+```
+
+Or, via JSON input:
+
+```json
+{
+  "project_file": "/workspace/trinity/trinity.hms",
+  "sim_name": "apr-may-1990",
+  "excess_precip": "/workspace/trinity/excess-precip_apr-may-1990.p01.tmp.hdf"
+}
+```
+
+```
+$ $ docker run -it -v /tmp/trinity:/workspace/trinity go-hms-runner --json-file /workspace/trinity/test-trinity.json
 ```

--- a/reference/hms/hms-golang/main.go
+++ b/reference/hms/hms-golang/main.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -49,20 +50,22 @@ func logError(src, m string)  { log.Error().Str("source", src).Msg(m) }
 /* ---------- CLI flags ---------------------------------------------------- */
 
 type cliCfg struct {
-	projectFile string
-	simName     string
-	example     bool
-	jsonFile    string
-	logFormat   string
+	projectFile  string
+	simName      string
+	excessPrecip string
+	jsonFile     string
+	example      bool
+	logFormat    string
 }
 
 func parseFlags() cliCfg {
 	var c cliCfg
-	flag.StringVar(&c.projectFile, "project-file", "",     ".hms project file")
-	flag.StringVar(&c.simName,     "sim-name",     "",     "simulation name")
-	flag.BoolVar(&c.example,       "example",      false,  "built-in example (tenk)")
-	flag.StringVar(&c.jsonFile,    "json-file",    "",     "JSON file with hms_schema")
-	flag.StringVar(&c.logFormat,   "log-format",   "text", "text | json")
+	flag.StringVar(&c.projectFile,  "project-file",  "",     ".hms project file")
+	flag.StringVar(&c.simName,      "sim-name",      "",     "simulation name")
+	flag.StringVar(&c.excessPrecip, "excess-precip", "",     "path to export spatial excess precip as RAS .p##.tmp.hdf file or .dss file")
+	flag.StringVar(&c.jsonFile,     "json-file",     "",     "configure HMS run with a JSON file based on the FFRD HMS schema")
+	flag.BoolVar(&c.example,        "example",       false,  "run built-in example (tenk)")
+	flag.StringVar(&c.logFormat,    "log-format",    "text", "text | json")
 	flag.Parse()
 	return c
 }
@@ -70,17 +73,44 @@ func parseFlags() cliCfg {
 /* ---------- helpers ------------------------------------------------------ */
 
 const jythonTpl = `from hms.model.JythonHms import *
-OpenProject("%s", "%s")
-ComputeRun("%s")
-SaveAllProjectComponents()
+from hms.model import Project
+from hms.model.data import SpatialVariableType
+
+from time import time
+
+project_name = "%s"
+project_dir = "%s"
+sim_name = "%s"
+excess_precip = "%s"
+
+def _print(msg):
+	print("Jython: " + str(msg))
+
+# Open project, compute sim, save
+project_path = project_dir + "/" + project_name + ".hms"
+_print("opening project: " + project_path)
+project = Project.open(project_path)
+project.computeRun(sim_name)
+_print("finished compute.")
+project.saveAll()
+_print("finished save.")
+
+# Export excess precip if requested
+if excess_precip:
+	_print("exporting spatial excess precip to: " + excess_precip)
+	spec = project.getComputeSpecification(sim_name)
+	t1 = time()
+	spec.exportSpatialResults(excess_precip, { SpatialVariableType.INC_EXCESS })
+	t2 = time()
+	_print("finished spatial excess precip export in " + str(t2 - t1) + " seconds.")
 `
 
-func buildJython(projectName, projectDir, simName string) (string, error) {
+func buildJython(projectName, projectDir, simName string, excessPrecip string) (string, error) {
 	tmp, err := os.CreateTemp("", "*.script")
 	if err != nil {
 		return "", err
 	}
-	code := fmt.Sprintf(jythonTpl, projectName, projectDir, simName)
+	code := fmt.Sprintf(jythonTpl, projectName, projectDir, simName, excessPrecip)
 	if _, err = tmp.WriteString(code); err != nil {
 		return "", err
 	}
@@ -93,6 +123,8 @@ func classifyAndLog(source, line string) {
 	case strings.Contains(line, "WARNING"):
 		logWarn(source, line)
 	case strings.Contains(line, "ERROR"):
+		logError(source, line)
+	case strings.Contains(line, "SEVERE"):
 		logError(source, line)
 	case strings.Contains(line, "NOTE"):
 		logInfo(source, line)
@@ -144,8 +176,9 @@ func main() {
 	}
 
 	var (
-		hmsFile string
-		simName string
+		hmsFile      string
+		simName      string
+		excessPrecip string
 	)
 
 	hmsHome := os.Getenv("HMS_HOME")
@@ -160,20 +193,20 @@ func main() {
 			logError(hmsRunner, "cannot read JSON file: "+e.Error())
 			os.Exit(1)
 		}
-		var data struct {
-			Schema struct {
-				ProjectFile string `json:"project_file"`
-				SimName     string `json:"sim_name"`
-			} `json:"hms_schema"`
+		type Schema struct {
+			ProjectFile  string `json:"project_file"`
+			SimName      string `json:"sim_name"`
+			ExcessPrecip string `json:"excess_precip,omitempty"`
 		}
-		if e = json.NewDecoder(f).Decode(&data); e != nil {
+		var s Schema
+		if e = json.NewDecoder(f).Decode(&s); e != nil {
 			logError(hmsRunner, "invalid JSON: "+e.Error())
 			os.Exit(1)
 		}
-		hmsFile, simName = data.Schema.ProjectFile, data.Schema.SimName
+		hmsFile, simName, excessPrecip = s.ProjectFile, s.SimName, s.ExcessPrecip
 
 	default:
-		hmsFile, simName = cfg.projectFile, cfg.simName
+		hmsFile, simName, excessPrecip = cfg.projectFile, cfg.simName, cfg.excessPrecip
 	}
 
 	if hmsFile == "" || !strings.HasSuffix(strings.ToLower(hmsFile), ".hms") {
@@ -184,12 +217,19 @@ func main() {
 		logError(hmsRunner, "sim_name is required")
 		os.Exit(1)
 	}
+	rasHdfRe := regexp.MustCompile(`.*\.p[0-9][0-9]\.(hdf|tmp\.hdf)$`)
+	if !rasHdfRe.MatchString(excessPrecip) &&
+		!strings.HasSuffix(strings.ToLower(excessPrecip), ".dss") &&
+		excessPrecip != "" {
+		logError(hmsRunner, "excess_precip must be a .p##.tmp.hdf file or .dss file")
+		os.Exit(1)
+	}
 
 	projectDir := filepath.Dir(hmsFile)
 	projectName := strings.TrimSuffix(filepath.Base(hmsFile), filepath.Ext(hmsFile))
 
 	// --- build Jython script ---------------------------------------------
-	scriptPath, e := buildJython(projectName, projectDir, simName)
+	scriptPath, e := buildJython(projectName, projectDir, simName, excessPrecip)
 	if e != nil {
 		logError(hmsRunner, "cannot write temp script: "+e.Error())
 		os.Exit(1)

--- a/reference/hms/hms_schema.json
+++ b/reference/hms/hms_schema.json
@@ -6,19 +6,19 @@
   "description": "Configuration for running a HEC-HMS model using a project file.",
   "type": "object",
   "properties": {
-    "program": {
-      "type": "string",
-      "enum": [
-        "hms"
-      ]
-    },
     "project_file": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "description": "Path to the HEC-HMS project file (.hms)."
     },
     "sim_name": {
       "type": "string",
-      "minLength": 1
+      "minLength": 1,
+      "description": "Name of the simulation within the HEC-HMS project to run."
+    },
+    "excess_precip": {
+      "type": "string",
+      "description": "Optional path to export spatial excess precipitation results (RAS HDF or DSS format)."
     }
   },
   "required": [


### PR DESCRIPTION
# Description
* Adds an `excess-precip` feature to _optionally_ export spatial excess precip after an HMS run is complete.
* This option can be omitted from CLI args or the input JSON file to skip exporting excess precip.
* Excess precip can be exported either in RAS HDF format (`.p##.tmp.hdf`) or `.dss` format.
* Adds HMS v4.13-beta.6 to CI builds

# Testing
* Download the Trinity HMS calibration model from Model Library, extract it, and put it in `/tmp/trinity` on your local machine (or another directory, making sure to update the path in testing steps below).
* Build the HMS container with HMS v4.13-beta.6:
```
$ cd ./reference/hms/hms-golang
$ docker build --build-arg HMS_VERSION=4.13-beta.6 -t go-hms-runner .
```
* To test with command-line arguments:
```
$ docker run -it -v /tmp/trinity:/workspace/trinity go-hms-runner --project-file /workspace/trinity/trinity.hms --sim-name apr-may-1990 --excess-precip /workspace/trinity/excess-precip.p01.tmp.hdf
```
* To test with JSON file input:
```json
{
  "project_file": "/workspace/trinity/trinity.hms",
  "sim_name": "apr-may-1990",
  "excess_precip": "/workspace/trinity/excess-precip_apr-may-1990.p01.tmp.hdf"
}
```
```
$ docker run -it -v /tmp/trinity:/workspace/trinity go-hms-runner --json-file /workspace/trinity/test-trinity.json
```